### PR TITLE
Add OS note to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Based on https://github.com/rafaelmardojai/firefox-gnome-theme
 
 ## Installation
 
+> [!note]
+> This project applies custom CSS to Firefox on Linux.
+> For other operating systems, refer to the [MacOS and Windows fork](#macos-and-windows-version).
+
 Run the following commands in the terminal:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Based on https://github.com/rafaelmardojai/firefox-gnome-theme
 
 > [!note]
 > This project applies custom CSS to Firefox on Linux.
-> For other operating systems, refer to the [MacOS and Windows fork](#macos-and-windows-version).
+> For other operating systems, refer to the [MacOS and Windows version](#macos-and-windows-version).
 
 Run the following commands in the terminal:
 


### PR DESCRIPTION
New users may not immediately realize this project is only for Firefox on Linux. (See #39)

This PR adds an explanatory note to the top of the Installation instructions so MacOS users don't attempt installation by mistake.