### PR TITLE
Update headerbar.css

### DIFF
--- a/src/common/parts/headerbar.css
+++ b/src/common/parts/headerbar.css
@@ -107,6 +107,10 @@ toolbar .toolbaritem-combined-buttons > .toolbarbutton-1 {
 	transition-duration: 100ms;
 }
 
+#urlbar[breakout] {
+	position: static !important; 
+}
+
 #urlbar[breakout][breakout-extend] #urlbar-input-container,
 #urlbar[breakout][breakout-extend] #urlbar-input-container:hover,
 #urlbar[breakout][breakout-extend] .urlbar-input-container,


### PR DESCRIPTION
In the file /src/common/parts/headerbar.css, I added the position: static property to the #urlbar[breakout] selector. This change was necessary because Firefox was automatically assigning the absolute value, which caused the URL bar to shrink or expand when clicked. By using the static property, this behavior has been prevented.