### PR TITLE
Url Bar fixed one issue

### DIFF
--- a/src/common/parts/headerbar.css
+++ b/src/common/parts/headerbar.css
@@ -111,6 +111,7 @@ toolbar .toolbaritem-combined-buttons > .toolbarbutton-1 {
 	position: static !important; 
 }
 
+/* New tab url bar focusing */
 #urlbar[focused]:not([suppress-focus-border]) > #urlbar-background, 
 #searchbar:focus-within {
     outline: none !important;

--- a/src/common/parts/headerbar.css
+++ b/src/common/parts/headerbar.css
@@ -111,6 +111,11 @@ toolbar .toolbaritem-combined-buttons > .toolbarbutton-1 {
 	position: static !important; 
 }
 
+#urlbar[focused]:not([suppress-focus-border]) > #urlbar-background, 
+#searchbar:focus-within {
+    outline: none !important;
+}
+
 #urlbar[breakout][breakout-extend] #urlbar-input-container,
 #urlbar[breakout][breakout-extend] #urlbar-input-container:hover,
 #urlbar[breakout][breakout-extend] .urlbar-input-container,


### PR DESCRIPTION
Removed the outline effect on the URL bar that appeared when opening a new tab, which caused a noticeable focus effect on both sides. Setting the outline to none has resulted in a cleaner, more subtle appearance when opening new tabs.
