### PR TITLE
Update renamed LWT vars for Firefox 151+

### DIFF
--- a/src/Monterey/colors/dark-adaptive.css
+++ b/src/Monterey/colors/dark-adaptive.css
@@ -22,8 +22,8 @@
 	--gnome-toolbar-background: var(--lwt-accent-color, #363636);
 	--gnome-tabstoolbar-background: var(--lwt-accent-color, #363636);
 	--gnome-findbar-background: var(--lwt-accent-color, #363636);
-	--gnome-toolbar-color: var(--toolbar-color, #ffffff);
-	--gnome-toolbar-icon-fill: var(--toolbar-color, #ffffff);
+	--gnome-toolbar-color: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
+	--gnome-toolbar-icon-fill: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
 	--gnome-toolbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-inactive-toolbar-color: color-mix(in srgb, var(--gnome-toolbar-color) 45%, var(--gnome-toolbar-background));
 	--gnome-inactive-toolbar-background: var(--lwt-accent-color, #363636);
@@ -35,9 +35,9 @@
 	--gnome-sidebar-border-color: color-mix(in srgb, var(--lwt-text-color) 12%, var(--lwt-sidebar-background-color));
 
 	/* Popups */
-	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-menu-border-color: rgba(0,0,0,.15);
-	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-popover-border-color: light-dark(rgba(0,0,0,.15), #000000);
 	--gnome-popover-shadow: 0 5px 8px rgba(0, 0, 0, 0.3);
 	--gnome-popover-button-hover-background: color-mix(in srgb, currentColor 10%, transparent);
@@ -97,7 +97,7 @@
 	--gnome-headerbar-button-active-background: color-mix(in srgb, currentColor 18%, transparent);
 
 	/* URL bar */
-	--gnome-urlbar-color: var(--toolbar-color, #ffffff);
+	--gnome-urlbar-color: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
 	--gnome-urlbar-background: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-box-shadow: 0 3px 6px 1px rgba(0,0,0, .2), 0 5px 16px 3px rgba(0,0,0, .15), 0 0 0 1px light-dark(rgba(0,0,0,.15), rgba(0,0,0,.75));
@@ -111,17 +111,17 @@
 	--gnome-private-urlbar-background: var(--toolbar-field-background-color);
 
 	/* Tabs */
-	--gnome-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color, #ffffff));
+	--gnome-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color, #ffffff)));
 	--gnome-tabbar-tab-background: var(--lwt-accent-color, #363636);
 	--gnome-tabbar-tab-border-color: var(--gnome-toolbar-border-color);
 	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 12%, var(--gnome-tabbar-tab-background));
 	--gnome-tabbar-tab-hover-border-bottom-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-hover-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-tabbar-tab-active-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 15%, var(--gnome-tabbar-tab-background));
 	--gnome-tabbar-tab-active-border-bottom-color: color-mix(in srgb, var(--gnome-tabbar-tab-color) 12%, var(--gnome-tabbar-tab-background));
-	--gnome-tabbar-tab-active-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-active-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 20%, var(--gnome-tabbar-tab-background));
-	--gnome-inactive-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-inactive-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-inactive-tabbar-tab-background: var(--gnome-tabstoolbar-background);
 	--gnome-inactive-tabbar-tab-active-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 8%, var(--gnome-tabbar-tab-background));
 	--gnome-inactive-tabbar-tab-active-border-bottom-color: var(--gnome-tabbar-tab-active-border-bottom-color);

--- a/src/Monterey/colors/dark.css
+++ b/src/Monterey/colors/dark.css
@@ -21,8 +21,8 @@
 	--gnome-toolbar-background: var(--lwt-accent-color, #373737);
 	--gnome-tabstoolbar-background: var(--lwt-accent-color, #1e1e1e);
 	--gnome-findbar-background: var(--lwt-accent-color, #373737);
-	--gnome-toolbar-color: var(--toolbar-color, #ffffff);
-	--gnome-toolbar-icon-fill: var(--toolbar-color, #ffffff);
+	--gnome-toolbar-color: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
+	--gnome-toolbar-icon-fill: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
 	--gnome-toolbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-inactive-toolbar-color: color-mix(in srgb, var(--gnome-toolbar-color) 45%, var(--gnome-toolbar-background));
 	--gnome-inactive-toolbar-background: var(--lwt-accent-color, #313131);
@@ -34,9 +34,9 @@
 	--gnome-sidebar-border-color: color-mix(in srgb, var(--lwt-text-color) 12%, var(--gnome-sidebar-background));
 
 	/* Popups */
-	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-menu-border-color: rgba(0,0,0,.15);
-	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-popover-border-color: light-dark(rgba(0,0,0,.15), #000000);
 	--gnome-popover-shadow: 0 5px 8px rgba(0, 0, 0, 0.3);
 	--gnome-popover-button-hover-background: color-mix(in srgb, currentColor 10%, transparent);
@@ -96,7 +96,7 @@
 	--gnome-headerbar-button-active-background: color-mix(in srgb, currentColor 18%, transparent);
 
 	/* URL bar */
-	--gnome-urlbar-color: var(--toolbar-color, #ffffff);
+	--gnome-urlbar-color: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
 	--gnome-urlbar-background: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-box-shadow: 0 3px 6px 1px rgba(0,0,0, .2), 0 5px 16px 3px rgba(0,0,0, .15), 0 0 0 1px light-dark(rgba(0,0,0,.15), rgba(0,0,0,.75));
@@ -110,16 +110,16 @@
 	--gnome-private-urlbar-background: var(--toolbar-field-background-color);
 
 	/* Tabs */
-	--gnome-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color, #ffffff));
+	--gnome-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color, #ffffff)));
 	--gnome-tabbar-tab-background: var(--lwt-accent-color, #373737);
 	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 12%, var(--gnome-tabbar-tab-background));
 	--gnome-tabbar-tab-hover-border-bottom-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-hover-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-tabbar-tab-active-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 15%, var(--gnome-tabbar-tab-background));
 	--gnome-tabbar-tab-active-border-bottom-color: color-mix(in srgb, var(--gnome-tabbar-tab-color) 12%, var(--gnome-tabbar-tab-background));
-	--gnome-tabbar-tab-active-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-active-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 20%, var(--gnome-tabbar-tab-background));
-	--gnome-inactive-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-inactive-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-inactive-tabbar-tab-background: var(--gnome-tabstoolbar-background);
 	--gnome-inactive-tabbar-tab-active-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 8%, var(--gnome-tabbar-tab-background));
 	--gnome-inactive-tabbar-tab-active-border-bottom-color: var(--gnome-tabbar-tab-active-border-bottom-color);

--- a/src/Monterey/colors/darker.css
+++ b/src/Monterey/colors/darker.css
@@ -21,8 +21,8 @@
 	--gnome-toolbar-background: var(--lwt-accent-color, #1e1e1e);
 	--gnome-tabstoolbar-background: var(--lwt-accent-color, #1e1e1e);
 	--gnome-findbar-background: var(--lwt-accent-color, #282828);
-	--gnome-toolbar-color: var(--toolbar-color, #ffffff);
-	--gnome-toolbar-icon-fill: var(--toolbar-color, #ffffff);
+	--gnome-toolbar-color: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
+	--gnome-toolbar-icon-fill: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
 	--gnome-toolbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-inactive-toolbar-color: color-mix(in srgb, var(--gnome-toolbar-color) 45%, var(--gnome-toolbar-background));
 	--gnome-inactive-toolbar-background: var(--lwt-accent-color, #1e1e1e);
@@ -34,9 +34,9 @@
 	--gnome-sidebar-border-color: color-mix(in srgb, var(--lwt-text-color) 12%, var(--gnome-sidebar-background));
 
 	/* Popups */
-	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-menu-border-color: rgba(0,0,0,.15);
-	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-popover-border-color: light-dark(rgba(0,0,0,.15), #000000);
 	--gnome-popover-shadow: 0 5px 8px rgba(0, 0, 0, 0.3);
 	--gnome-popover-button-hover-background: color-mix(in srgb, currentColor 10%, transparent);
@@ -96,7 +96,7 @@
 	--gnome-headerbar-button-active-background: color-mix(in srgb, currentColor 18%, transparent);
 
 	/* URL bar */
-	--gnome-urlbar-color: var(--toolbar-color, #ffffff);
+	--gnome-urlbar-color: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
 	--gnome-urlbar-background: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-box-shadow: 0 3px 6px 1px rgba(0,0,0, .2), 0 5px 16px 3px rgba(0,0,0, .15), 0 0 0 1px light-dark(rgba(0,0,0,.15), rgba(0,0,0,.75));
@@ -110,16 +110,16 @@
 	--gnome-private-urlbar-background: var(--toolbar-field-background-color);
 
 	/* Tabs */
-	--gnome-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color, #ffffff));
+	--gnome-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color, #ffffff)));
 	--gnome-tabbar-tab-background: var(--lwt-accent-color, #1e1e1e);
 	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 12%, var(--gnome-tabbar-tab-background));
 	--gnome-tabbar-tab-hover-border-bottom-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-hover-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-tabbar-tab-active-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 15%, var(--gnome-tabbar-tab-background));
 	--gnome-tabbar-tab-active-border-bottom-color: color-mix(in srgb, var(--gnome-tabbar-tab-color) 12%, var(--gnome-tabbar-tab-background));
-	--gnome-tabbar-tab-active-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-active-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 20%, var(--gnome-tabbar-tab-background));
-	--gnome-inactive-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-inactive-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-inactive-tabbar-tab-background: var(--gnome-tabstoolbar-background);
 	--gnome-inactive-tabbar-tab-active-background: color-mix(in srgb, var(--gnome-tabbar-tab-color) 8%, var(--gnome-tabbar-tab-background));
 	--gnome-inactive-tabbar-tab-active-border-bottom-color: var(--gnome-tabbar-tab-active-border-bottom-color);

--- a/src/Monterey/colors/light-adaptive.css
+++ b/src/Monterey/colors/light-adaptive.css
@@ -25,8 +25,8 @@
 	--gnome-toolbar-background: var(--lwt-accent-color, #ffffff);
 	--gnome-tabstoolbar-background: var(--lwt-accent-color, #ffffff);
 	--gnome-findbar-background: var(--lwt-accent-color, #ffffff);
-	--gnome-toolbar-color: var(--toolbar-color, #2e2e2e);
-	--gnome-toolbar-icon-fill: var(--toolbar-color, #2e2e2e);
+	--gnome-toolbar-color: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
+	--gnome-toolbar-icon-fill: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
 	--gnome-toolbar-border-color: var(--chrome-content-separator-color);
 	--gnome-inactive-toolbar-color: color-mix(in srgb, var(--gnome-toolbar-color) 45%, var(--gnome-toolbar-background));
 	--gnome-inactive-toolbar-background: var(--lwt-accent-color, #ffffff);
@@ -35,12 +35,12 @@
 	/* Sidebar */
 	--gnome-sidebar-background: var(--lwt-accent-color, #ffffff);
 	--gnome-inactive-sidebar-background: var(--lwt-accent-color, #ffffff);
-	--gnome-sidebar-border-color: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-sidebar-background));
+	--gnome-sidebar-border-color: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-sidebar-background));
 
 	/* Popups */
-	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-menu-border-color: rgba(0,0,0,.15);
-	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-popover-border-color: light-dark(rgba(0,0,0,.15), #000000);
 	--gnome-popover-shadow: 0 5px 8px rgba(0, 0, 0, 0.15);
 	--gnome-popover-button-hover-background: color-mix(in srgb, currentColor 10%, transparent);
@@ -100,7 +100,7 @@
 	--gnome-headerbar-button-active-background: color-mix(in srgb, currentColor 15%, transparent);
 
 	/* URL bar */
-	--gnome-urlbar-color: var(--toolbar-color, #2e2e2e);
+	--gnome-urlbar-color: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
 	--gnome-urlbar-background: color-mix(in srgb, currentColor 8%, transparent);
 	--gnome-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.08), 0 5px 8px rgba(0, 0, 0, 0.05), 0 8px 16px rgba(0, 0, 0, 0.03), 0 0 0 1px rgba(0,0,0, 0.12);
@@ -115,16 +115,16 @@
 
 	/* Tabs */
 	--gnome-tabbar-tab-background: var(--gnome-tabstoolbar-background);
-	--gnome-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color, #2e2e2e));
+	--gnome-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color, #2e2e2e)));
 	--gnome-tabbar-tab-border-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--toolbar-color) 5%, var(--gnome-tabstoolbar-background));
+	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 5%, var(--gnome-tabstoolbar-background));
 	--gnome-tabbar-tab-hover-border-bottom-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-color: var(--lwt-tab-text, var(--toolbar-color));
-	--gnome-tabbar-tab-active-background: color-mix(in srgb, var(--toolbar-color) 8%, var(--gnome-tabstoolbar-background));
-	--gnome-tabbar-tab-active-border-bottom-color: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-tabstoolbar-background));
-	--gnome-tabbar-tab-active-color: var(--lwt-tab-text, var(--toolbar-color));
-	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-tabstoolbar-background));
-	--gnome-inactive-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-hover-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
+	--gnome-tabbar-tab-active-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 8%, var(--gnome-tabstoolbar-background));
+	--gnome-tabbar-tab-active-border-bottom-color: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-tabstoolbar-background));
+	--gnome-tabbar-tab-active-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
+	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-tabstoolbar-background));
+	--gnome-inactive-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-inactive-tabbar-tab-background: var(--gnome-tabstoolbar-background);
 	--gnome-inactive-tabbar-tab-active-background: var(--gnome-headerbar-background);
 	--gnome-inactive-tabbar-tab-active-border-bottom-color: var(--gnome-tabbar-tab-active-border-bottom-color);

--- a/src/Monterey/colors/light.css
+++ b/src/Monterey/colors/light.css
@@ -20,8 +20,8 @@
 	--gnome-toolbar-background: var(--lwt-accent-color, #ffffff);
 	--gnome-tabstoolbar-background: var(--lwt-accent-color, #E5E5E5);
 	--gnome-findbar-background: var(--lwt-accent-color, #ffffff);
-	--gnome-toolbar-color: var(--toolbar-color, #2e2e2e);
-	--gnome-toolbar-icon-fill: var(--toolbar-color, #2e2e2e);
+	--gnome-toolbar-color: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
+	--gnome-toolbar-icon-fill: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
 	--gnome-toolbar-border-color: var(--chrome-content-separator-color, #cfcfcf);
 	--gnome-inactive-toolbar-color: color-mix(in srgb, var(--gnome-toolbar-color) 45%, var(--gnome-toolbar-background));
 	--gnome-inactive-toolbar-background: var(--lwt-accent-color, #f6f5f4);
@@ -30,12 +30,12 @@
 	/* Sidebar */
 	--gnome-sidebar-background: var(--lwt-accent-color, #f5f5f5);
 	--gnome-inactive-sidebar-background: var(--lwt-accent-color, #f9f9f8);
-	--gnome-sidebar-border-color: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-sidebar-background));
+	--gnome-sidebar-border-color: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-sidebar-background));
 
 	/* Popups */
-	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-menu-border-color: rgba(0,0,0,.15);
-	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-popover-border-color: light-dark(rgba(0,0,0,.15), #000000);
 	--gnome-popover-shadow: 0 5px 8px rgba(0, 0, 0, 0.15);
 	--gnome-popover-button-hover-background: color-mix(in srgb, currentColor 10%, transparent);
@@ -98,7 +98,7 @@
 	--gnome-urlbar-background: color-mix(in srgb, currentColor 8%, transparent);
 	--gnome-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.08), 0 5px 8px rgba(0, 0, 0, 0.05), 0 8px 16px rgba(0, 0, 0, 0.03), 0 0 0 1px rgba(0,0,0, 0.12);
-	--gnome-urlbar-color: var(--toolbar-color, #2e2e2e);
+	--gnome-urlbar-color: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
 	--gnome-hover-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-inactive-urlbar-background: color-mix(in srgb, currentColor 4%, transparent);
 	--gnome-inactive-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
@@ -110,15 +110,15 @@
 
 	/* Tabs */
 	--gnome-tabbar-tab-background: var(--gnome-tabstoolbar-background);
-	--gnome-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color, #2e2e2e));
-	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--toolbar-color) 5%, var(--gnome-tabstoolbar-background));
+	--gnome-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color, #2e2e2e)));
+	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 5%, var(--gnome-tabstoolbar-background));
 	--gnome-tabbar-tab-hover-border-bottom-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-color: var(--lwt-tab-text, var(--toolbar-color));
-	--gnome-tabbar-tab-active-background: color-mix(in srgb, var(--toolbar-color) 8%, var(--gnome-tabstoolbar-background));
-	--gnome-tabbar-tab-active-border-bottom-color: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-tabstoolbar-background));
-	--gnome-tabbar-tab-active-color: var(--lwt-tab-text, var(--toolbar-color));
-	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-tabstoolbar-background));
-	--gnome-inactive-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-hover-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
+	--gnome-tabbar-tab-active-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 8%, var(--gnome-tabstoolbar-background));
+	--gnome-tabbar-tab-active-border-bottom-color: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-tabstoolbar-background));
+	--gnome-tabbar-tab-active-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
+	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-tabstoolbar-background));
+	--gnome-inactive-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-inactive-tabbar-tab-background: var(--gnome-tabstoolbar-background);
 	--gnome-inactive-tabbar-tab-active-background: var(--gnome-headerbar-background);
 	--gnome-inactive-tabbar-tab-active-border-bottom-color: var(--gnome-tabbar-tab-active-border-bottom-color);

--- a/src/WhiteSur/colors/dark-adaptive.css
+++ b/src/WhiteSur/colors/dark-adaptive.css
@@ -25,8 +25,8 @@
 	--gnome-toolbar-background: var(--lwt-accent-color, #363636);
 	--gnome-tabstoolbar-background: color-mix(in srgb, #ffffff 6%, var(--lwt-accent-color, #363636));
 	--gnome-findbar-background: var(--lwt-accent-color, #282828);
-	--gnome-toolbar-color: var(--toolbar-color, #ffffff);
-	--gnome-toolbar-icon-fill: var(--toolbar-color, #ffffff);
+	--gnome-toolbar-color: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
+	--gnome-toolbar-icon-fill: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
 	--gnome-toolbar-border-color: rgba(255, 255, 255, 0.1);
 	--gnome-inactive-toolbar-color: color-mix(in srgb, var(--gnome-toolbar-color) 45%, var(--gnome-toolbar-background));
 	--gnome-inactive-toolbar-background: var(--lwt-accent-color, #282828);
@@ -35,12 +35,12 @@
 	/* Sidebar */
 	--gnome-sidebar-background: var(--lwt-accent-color, #282828);
 	--gnome-inactive-sidebar-background: var(--lwt-accent-color, #282828);
-	--gnome-sidebar-border-color: color-mix(in srgb, var(--toolbar-color) 10%, var(--gnome-sidebar-background));
+	--gnome-sidebar-border-color: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 10%, var(--gnome-sidebar-background));
 
 	/* Popups */
-	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-menu-border-color: rgba(0,0,0,.15);
-	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-popover-border-color: light-dark(rgba(0,0,0,.15), #000000);
 	--gnome-popover-shadow: 0 5px 8px rgba(0, 0, 0, 0.3);
 	--gnome-popover-button-hover-background: color-mix(in srgb, currentColor 10%, transparent);
@@ -100,7 +100,7 @@
 	--gnome-headerbar-button-active-background: color-mix(in srgb, currentColor 18%, transparent);
 
 	/* URL bar */
-	--gnome-urlbar-color: var(--toolbar-color, #ffffff);
+	--gnome-urlbar-color: var(--toolbar-text-color, var(--toolbar-color, #ffffff));
 	--gnome-urlbar-background: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-box-shadow: 0 3px 6px 1px rgba(0,0,0, .2), 0 5px 16px 3px rgba(0,0,0, .15), 0 0 0 1px rgba(0, 0, 0, 0.75);
@@ -114,17 +114,17 @@
 	--gnome-private-urlbar-background: var(--toolbar-field-background-color);
 
 	/* Tabs */
-	--gnome-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color, #ffffff));
+	--gnome-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color, #ffffff)));
 	--gnome-tabbar-tab-background: var(--lwt-accent-color, #363636);
 	--gnome-tabbar-tab-border-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--toolbar-color) 12%, var(--lwt-accent-color));
+	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--lwt-accent-color));
 	--gnome-tabbar-tab-hover-border-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-hover-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-tabbar-tab-active-background: var(--gnome-headerbar-background);
-	--gnome-tabbar-tab-active-border-color: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-headerbar-background));
-	--gnome-tabbar-tab-active-color: var(--lwt-tab-text, var(--toolbar-color));
-	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--toolbar-color) 12%, var(--lwt-accent-color));
-	--gnome-inactive-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-active-border-color: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-headerbar-background));
+	--gnome-tabbar-tab-active-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
+	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--lwt-accent-color));
+	--gnome-inactive-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-inactive-tabbar-tab-background: var(--gnome-tabstoolbar-background);
 	--gnome-inactive-tabbar-tab-active-background: var(--gnome-headerbar-background);
 	--gnome-inactive-tabbar-tab-active-border-color: var(--gnome-tabbar-tab-active-border-bottom-color);

--- a/src/WhiteSur/colors/light-adaptive.css
+++ b/src/WhiteSur/colors/light-adaptive.css
@@ -24,8 +24,8 @@
 	--gnome-toolbar-background: var(--lwt-accent-color, #ffffff);
 	--gnome-tabstoolbar-background: color-mix(in srgb, currentColor 8%, var(--gnome-toolbar-background));
 	--gnome-findbar-background: var(--lwt-accent-color, #ffffff);
-	--gnome-toolbar-color: var(--toolbar-color, #2e2e2e);
-	--gnome-toolbar-icon-fill: var(--toolbar-color, #2e2e2e);
+	--gnome-toolbar-color: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
+	--gnome-toolbar-icon-fill: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
 	--gnome-toolbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-inactive-toolbar-color: color-mix(in srgb, var(--gnome-toolbar-color) 45%, var(--gnome-toolbar-background));
 	--gnome-inactive-toolbar-background: var(--lwt-accent-color, #ffffff);
@@ -34,12 +34,12 @@
 	/* Sidebar */
 	--gnome-sidebar-background: var(--lwt-accent-color, #ffffff);
 	--gnome-inactive-sidebar-background: var(--lwt-accent-color, #ffffff);
-	--gnome-sidebar-border-color: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-sidebar-background));
+	--gnome-sidebar-border-color: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-sidebar-background));
 
 	/* Popups */
-	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-menu-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-menu-border-color: rgba(0,0,0,.15);
-	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-focus-background-color) 95%, transparent);
+	--gnome-popover-background: color-mix(in srgb, var(--toolbar-field-background-color-focus, var(--toolbar-field-focus-background-color)) 95%, transparent);
 	--gnome-popover-border-color: light-dark(rgba(0,0,0,.15), #000000);
 	--gnome-popover-shadow: 0 5px 8px rgba(0, 0, 0, 0.15);
 	--gnome-popover-button-hover-background: color-mix(in srgb, currentColor 10%, transparent);
@@ -99,7 +99,7 @@
 	--gnome-headerbar-button-active-background: color-mix(in srgb, currentColor 15%, transparent);
 
 	/* URL bar */
-	--gnome-urlbar-color: var(--toolbar-color, #2e2e2e);
+	--gnome-urlbar-color: var(--toolbar-text-color, var(--toolbar-color, #2e2e2e));
 	--gnome-urlbar-background: color-mix(in srgb, currentColor 8%, transparent);
 	--gnome-urlbar-border-color: color-mix(in srgb, currentColor 10%, transparent);
 	--gnome-urlbar-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.08), 0 5px 8px rgba(0, 0, 0, 0.05), 0 8px 16px rgba(0, 0, 0, 0.03), 0 0 0 1px rgba(0,0,0, 0.12);
@@ -114,16 +114,16 @@
 
 	/* Tabs */
 	--gnome-tabbar-tab-background: var(--gnome-tabstoolbar-background);
-	--gnome-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color, #2e2e2e));
+	--gnome-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color, #2e2e2e)));
 	--gnome-tabbar-tab-border-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-tabstoolbar-background));
+	--gnome-tabbar-tab-hover-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-tabstoolbar-background));
 	--gnome-tabbar-tab-hover-border-color: var(--gnome-toolbar-border-color);
-	--gnome-tabbar-tab-hover-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-hover-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-tabbar-tab-active-background: var(--gnome-headerbar-background);
-	--gnome-tabbar-tab-active-border-color: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-headerbar-background));
-	--gnome-tabbar-tab-active-color: var(--lwt-tab-text, var(--toolbar-color));
-	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--toolbar-color) 12%, var(--gnome-tabstoolbar-background));
-	--gnome-inactive-tabbar-tab-color: var(--lwt-tab-text, var(--toolbar-color));
+	--gnome-tabbar-tab-active-border-color: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-headerbar-background));
+	--gnome-tabbar-tab-active-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
+	--gnome-tabbar-tab-active-hover-background: color-mix(in srgb, var(--toolbar-text-color, var(--toolbar-color)) 12%, var(--gnome-tabstoolbar-background));
+	--gnome-inactive-tabbar-tab-color: var(--toolbar-text-color, var(--lwt-tab-text, var(--toolbar-color)));
 	--gnome-inactive-tabbar-tab-background: var(--gnome-tabstoolbar-background);
 	--gnome-inactive-tabbar-tab-active-background: var(--gnome-headerbar-background);
 	--gnome-inactive-tabbar-tab-active-border-color: var(--gnome-tabbar-tab-active-border-bottom-color);


### PR DESCRIPTION
Firefox 151 renamed the LightweightTheme CSS variables that this theme uses which breaks popups and the adaptive text/icons. I changed the variable references and added a fallback.

- Popup backgrounds (URL bar autocomplete, hamburger menu, etc.) changed from `--toolbar-field-focus-background-color` to `--toolbar-field-background-color-focus` 
- Tab text, URL bar text, toolbar text/icons (burger, extensions, etc.) changed from `--toolbar-color` into `--toolbar-text-color`
- Tab borders

Some screenshots here. I have the adaptive and alt options enabled:
<img width="1913" height="440" alt="image" src="https://github.com/user-attachments/assets/024641d0-c179-4747-ae9f-d38785422d8f" />
<img width="1913" height="440" alt="image" src="https://github.com/user-attachments/assets/5539ff9f-8b3f-4890-8d22-eed9f0dba2b7" />
<img width="1913" height="440" alt="image" src="https://github.com/user-attachments/assets/d392bc9c-e423-4c05-bfb1-c49b931d11b2" />

Can't take screenshot of the URL/search autocomplete but it's no longer transparent.

This should fix #86 and #87 . Might be related https://bugzilla.mozilla.org/show_bug.cgi?id=2034495